### PR TITLE
feat: implement db backup script and docs for lscs-links

### DIFF
--- a/scripts/backup/README.md
+++ b/scripts/backup/README.md
@@ -1,0 +1,28 @@
+\# Database Backup Documentation
+
+
+
+\## LSCS Links Backup Script (`db\_backup.sh`)
+
+
+
+\### How the script works
+
+The `db\_backup.sh` script automates the backup of the LSCS Links MongoDB database. It uses a Dockerized `mongodump` to connect to the external database via a connection string (configured in Dokploy). It streams the backup directly into a compressed `.archive` file and saves it in the `/home/lscs/backup/lscs-links/` directory with a timestamp.
+
+
+
+\### The applications affected
+
+\* LSCS Links Web
+
+\* LSCS Links API
+
+
+
+\#### DNS Names
+
+\* Development: `dev.links.dlsu-lscs.org`
+
+\* Production: `links.dlsu-lscs.org`
+


### PR DESCRIPTION
### What I did
* Implemented `db_backup.sh` for LSCS Links.
* Added documentation to `scripts/backup/README.md`.

### The Backup Flow
1. The script establishes a direct connection to the MongoDB database hosted on Dokploy using the provided external connection string.
2. It spins up a temporary `mongo:latest` Docker container to run `mongodump`, streaming the data directly to the host machine.
3. The output is compressed into a `.archive` file with a daily timestamp.
4. The file is strictly routed to the absolute path `/home/lscs/backup/lscs-links/`.
*Note: Environment variables (.env) are currently secured and managed directly within the Dokploy UI.*

@ejsadiarin - Ready for review!